### PR TITLE
Attempt patch version bump

### DIFF
--- a/.github/workflows/publish-on-merge.yml
+++ b/.github/workflows/publish-on-merge.yml
@@ -69,8 +69,14 @@ jobs:
         run: |
           BUMP_TYPE="${{ steps.bump_type.outputs.BUMP_TYPE }}"
           echo "Bumping $BUMP_TYPE version..."
-          npm version $BUMP_TYPE -m "chore: bump version to %s [skip ci]"
-          echo "NEW_VERSION=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+          npm version $BUMP_TYPE --no-git-tag-version
+          NEW_VERSION=$(node -p "require('./package.json').version")
+          echo "NEW_VERSION=$NEW_VERSION" >> $GITHUB_OUTPUT
+          
+          # Commit all changes including build artifacts
+          git add -A
+          git commit -m "chore: bump version to $NEW_VERSION [skip ci]"
+          git tag "v$NEW_VERSION"
       
       - name: Push changes and tags
         run: |


### PR DESCRIPTION
Manually commit version bump changes in GitHub Actions to include build artifacts and resolve 'Git working directory not clean' errors.

The previous setup failed because `npm version` requires a clean git working directory, but build artifacts were created before the bump and were not ignored. This change uses `npm version --no-git-tag-version` and then manually stages all changes (including build artifacts), commits, and tags.

---
<a href="https://cursor.com/background-agent?bcId=bc-1661d63e-04de-4a42-b739-4470ec5ad981"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1661d63e-04de-4a42-b739-4470ec5ad981"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

