### PR TITLE
ci: use supported Node for publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22.22.2'
           registry-url: 'https://registry.npmjs.org'
       
       - name: Install npm@latest


### PR DESCRIPTION
Pins the publish job to Node 22.22.2 so the current npm release can install and the automated patch publication can proceed. YAML syntax validated locally.