### PR TITLE
ci: pin supported npm release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,8 +42,8 @@ jobs:
           node-version: '22.22.2'
           registry-url: 'https://registry.npmjs.org'
       
-      - name: Install npm@latest
-        run: npm install -g npm@latest
+      - name: Install npm 11
+        run: npm install -g npm@11.6.2
       
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
## Summary\n- pin the publish workflow to npm 11.6.2\n- retain Node 22.22.2\n- avoid the npm 12 engine mismatch and npm self-upgrade failure that blocked the automated patch release\n\n## Validation\n- parsed the workflow with Ruby YAML\n- git diff --check\n\nThis is the smallest release-pipeline repair needed to publish the already-merged package metadata update.